### PR TITLE
Solve schema not found on migrate

### DIFF
--- a/src/migrations/2016_08_03_072804_create_districts_table.php
+++ b/src/migrations/2016_08_03_072804_create_districts_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 


### PR DESCRIPTION
[Symfony\Component\Debug\Exception\FatalThrowableError]
Class 'Schema' not found