### PR TITLE
Update custom table prefix configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,15 @@ $app->register(Laravolt\Indonesia\ServiceProvider::class);
 class_alias(Laravolt\Indonesia\Facade::class, 'Indonesia');
 ```
 
-Untuk mengatur prefix tabel, buat file `config/indonesia.php`, lalu copy kode berikut (ganti `indonesia_` dengan nilai prefix tabel yang diinginkan),
+Untuk mengatur prefix tabel, buat file `config/laravolt.php`, lalu copy kode berikut (ganti `indonesia_` dengan nilai prefix tabel yang diinginkan),
 ```
 <?php
 
 return [
-	'table_prefix' => 'indonesia_',
+    'indonesia' => [
+        'table_prefix' => 'indonesia_',
+    ],
 ];
-```
-Lalu daftarkan konfigurasi dalam `bootstrap/app.php` dengan menambahkan kode berikut.
-```
-$app->configure('indonesia');
 ```
 
 ### Publish Migration (Hanya Untuk Laravel/Lumen 5.2)


### PR DESCRIPTION
This pull request update the guide on readme file to set custom table prefix value.

Rationale:

- The `$app->configure()` method are no longer available on Laravel 6.x
- Should be works just fine on older version of Laravel