### PR TITLE
Add 8.0 PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "illuminate/support": "^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
I'm building a library coded according to php 8 and need the laravolt / indonesia package, but laravolt / indonesia does not support package installation in a php 8.0 environment. There is no change in the code base, only so that it can be installed on php 8.0.